### PR TITLE
Add solution file

### DIFF
--- a/interview-csharp-check.sln
+++ b/interview-csharp-check.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30114.105
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Check", "Check\Check.csproj", "{EF57FF8A-A290-4626-BC53-DAF66BFA38D9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Check.Tests", "Check.Tests\Check.Tests.csproj", "{6FCB587D-41AE-40A2-8B71-DB8B5ECB6BB0}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EF57FF8A-A290-4626-BC53-DAF66BFA38D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EF57FF8A-A290-4626-BC53-DAF66BFA38D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EF57FF8A-A290-4626-BC53-DAF66BFA38D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EF57FF8A-A290-4626-BC53-DAF66BFA38D9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6FCB587D-41AE-40A2-8B71-DB8B5ECB6BB0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6FCB587D-41AE-40A2-8B71-DB8B5ECB6BB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6FCB587D-41AE-40A2-8B71-DB8B5ECB6BB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6FCB587D-41AE-40A2-8B71-DB8B5ECB6BB0}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Many candidates are not familiar with the CLI, and those that are often are unaware of some of the quirks. Having a solution file allows candidates to open a terminal and run `dotnet build` and `dotnet test` without worrying about directories.